### PR TITLE
Add JUnit tests for add-pet command and fix multi-word parsing

### DIFF
--- a/src/main/java/seedu/cuddlecare/Pet.java
+++ b/src/main/java/seedu/cuddlecare/Pet.java
@@ -30,6 +30,20 @@ public class Pet {
         return name;
     }
 
+    /**
+     * Returns the species of the pet.
+     */
+    public String getSpecies() {
+        return species;
+    }
+
+    /**
+     * Returns the age of the pet.
+     */
+    public int getAge() {
+        return age;
+    }
+
     public void addTreatment(Treatment treatment) {
         treatments.add(treatment);
     }

--- a/src/main/java/seedu/cuddlecare/command/impl/AddPetCommand.java
+++ b/src/main/java/seedu/cuddlecare/command/impl/AddPetCommand.java
@@ -36,7 +36,7 @@ public class AddPetCommand implements Command {
     @Override
     public void exec(String args) {
         try {
-            String[] parts = args.split(" ");
+            String[] parts = args.trim().split("(?=\\bn/|\\bs/|\\ba/)");
 
             String name = null;
             String species = null;
@@ -44,9 +44,9 @@ public class AddPetCommand implements Command {
 
             for (String part : parts) {
                 if (part.startsWith("n/")) {
-                    name = part.substring(2);
+                    name = part.substring(2).trim();
                 } else if (part.startsWith("s/")) {
-                    species = part.substring(2);
+                    species = part.substring(2).trim();
                 } else if (part.startsWith("a/")) {
                     age = Integer.parseInt(part.substring(2));
                 }

--- a/src/test/java/seedu/cuddlecare/command/impl/AddPetCommandTest.java
+++ b/src/test/java/seedu/cuddlecare/command/impl/AddPetCommandTest.java
@@ -1,0 +1,111 @@
+package seedu.cuddlecare.command.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.cuddlecare.Pet;
+import seedu.cuddlecare.PetList;
+
+/**
+ * Tests for {@link AddPetCommand}.
+ * 
+ * These tests validate that pets are created and added properly to the list.
+ */
+public class AddPetCommandTest {
+    
+    private PetList petList;
+    private ByteArrayOutputStream outContent;
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    void setUp() {
+        petList = new PetList();
+
+        outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void exec_validInput_addsPet() {
+        AddPetCommand command = new AddPetCommand(petList);
+
+        String input = "n/Fluffy s/Cat a/3";
+        command.exec(input);
+
+        assertEquals(1, petList.size());
+        Pet newPet = petList.get(0);
+        assertEquals("Fluffy", newPet.getName());
+        assertEquals("Cat", newPet.getSpecies());
+        assertEquals(3, newPet.getAge());
+        assertTrue(outContent.toString().contains("Fluffy has been successfully added."));
+    }
+
+    @Test
+    void exec_inputWithMultipleWords_stillParses() {
+        AddPetCommand command = new AddPetCommand(petList);
+
+        String input = "n/James Bond s/Golden Retriever a/5  ";
+        command.exec(input);
+
+        assertEquals(1, petList.size());
+        Pet newPet = petList.get(0);
+        assertEquals("James Bond", newPet.getName());
+        assertEquals("Golden Retriever", newPet.getSpecies());
+        assertEquals(5, newPet.getAge());
+    }
+
+    @Test
+    void exec_inputWithExtraSpaces_stillParses() {
+        AddPetCommand command = new AddPetCommand(petList);
+
+        String input = "   n/Buddy   s/Dog    a/5  ";
+        command.exec(input);
+
+        assertEquals(1, petList.size());
+        Pet newPet = petList.get(0);
+        assertEquals("Buddy", newPet.getName());
+        assertEquals("Dog", newPet.getSpecies());
+        assertEquals(5, newPet.getAge());
+    }
+
+    @Test
+    void exec_missingArgument_showsError() {
+        AddPetCommand command = new AddPetCommand(petList);
+
+        command.exec("n/Fluffy");
+        assertEquals(0, petList.size());
+        assertTrue(outContent.toString().contains("Invalid input. Please try again."));
+    }
+
+    @Test
+    void exec_invalidAge_showsError() {
+        AddPetCommand command = new AddPetCommand(petList);
+
+        command.exec("n/Fluffy s/Cat a/three");
+        assertEquals(0, petList.size());
+        assertTrue(outContent.toString().contains("Age must be a valid number."));
+    }
+
+    @Test
+    void exec_duplicatePet_showsError() {
+        AddPetCommand command = new AddPetCommand(petList);
+
+        command.exec("n/Fluffy s/Cat a/3");
+        command.exec("n/Fluffy s/Cat a/3");
+
+        assertEquals(1, petList.size());
+        assertTrue(outContent.toString().contains("A pet with that name already exists."));
+    }
+}


### PR DESCRIPTION
Currently, CuddleCare's add-pet command does not have JUnit tests, which is not ideal for future code development and code quality. CuddleCare's add-pet command also does not support multi-word entries for the name and species currently.

Introduce JUnit tests that assesses the necessary cases to ensure the strength of the command within the application.

Implement multi-word parsing for the name and species within the input.

This woudl help with the strength of the add-pet command.