### PR TITLE
Make HelpCommand more defensive

### DIFF
--- a/src/main/java/seedu/cuddlecare/command/impl/HelpCommand.java
+++ b/src/main/java/seedu/cuddlecare/command/impl/HelpCommand.java
@@ -117,7 +117,7 @@ public class HelpCommand implements Command {
         String[] parts = args.split(" (?=[\\w+]/)");
         for (String part : parts) {
             if (part.startsWith(tag)) {
-                return part.substring(tag.length() + 1);
+                return part.substring(tag.length() + 1).trim().toLowerCase();
             }
         }
         return null;


### PR DESCRIPTION
Trims the commandName such that it doesn't say command not found due to extra spaces. Also makes the commandName lowercase to make it uniform

Fixes #126 